### PR TITLE
Ciclo de vida en el componente EntryForm.vue

### DIFF
--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -135,11 +135,9 @@ export default {
       return this.entryAttempts;
     }
   },
-  /*
-    mounted(){
-      this.localStorageSettingItems();
-    }
-  */
+  mounted(){
+    this.localStorageSettingItems();
+  }
 }
 </script>
 

--- a/src/components/EntryForm.vue
+++ b/src/components/EntryForm.vue
@@ -134,9 +134,6 @@ export default {
     attemptIncremented(){
       return this.entryAttempts;
     }
-  },
-  mounted(){
-    this.localStorageSettingItems();
   }
 }
 </script>


### PR DESCRIPTION
Se ha eliminado el reciente uso del ciclo de vida mounted() en el componente EntryForm.vue. Esto se ha realizado para plantear una mejor estructura y uso de los ciclos de vida de la aplicación y sus componentes en un futuro cercano.